### PR TITLE
Added check to make sure name field existed before accessing it.

### DIFF
--- a/src/Spring.Social.LinkedIn/Social/LinkedIn/Api/Impl/Json/LinkedInFullProfileDeserializer.cs
+++ b/src/Spring.Social.LinkedIn/Social/LinkedIn/Api/Impl/Json/LinkedInFullProfileDeserializer.cs
@@ -47,7 +47,7 @@ namespace Spring.Social.LinkedIn.Api.Impl.Json
             profile.IsConnectionsCountCapped = json.GetValue<bool>("numConnectionsCapped");
             JsonValue locationJson = json.GetValue("location");
             profile.CountryCode = locationJson.GetValue("country").GetValue<string>("code");
-            profile.Location = locationJson.GetValue<string>("name");
+            profile.Location = locationJson.ContainsName("name") ? locationJson.GetValue<string>("name") : "";
             profile.MainAddress = json.ContainsName("mainAddress") ? json.GetValue<string>("mainAddress") : "";
             profile.PhoneNumbers = DeserializePhoneNumbers(json.GetValue("phoneNumbers"));
             profile.Positions = DeserializePositions(json.GetValue("positions"));


### PR DESCRIPTION
Here is the error being thrown that was fixed:

Spring.Json.JsonException: The JSON object structure does not have an entry named 'name'.
   at Spring.Json.JsonValue.GetValue[T](String name) in f:\bamboo-home\xml-data\build-dir\SPRNETREST-RELEASE-JOB1\src\Spring.Rest\Json\JsonValue.cs:line 401
   at Spring.Social.LinkedIn.Api.Impl.Json.LinkedInFullProfileDeserializer.DeserializeCompany(JsonValue json) in f:\bamboo-home\xml-data\build-dir\SPRNETSOCIALLI-RELEASE-JOB1\src\Spring.Social.LinkedIn\Social\LinkedIn\Api\Impl\Json\LinkedInFullProfileDeserializer.cs:line 282
   at Spring.Social.LinkedIn.Api.Impl.Json.LinkedInFullProfileDeserializer.DeserializePositions(JsonValue json) in f:\bamboo-home\xml-data\build-dir\SPRNETSOCIALLI-RELEASE-JOB1\src\Spring.Social.LinkedIn\Social\LinkedIn\Api\Impl\Json\LinkedInFullProfileDeserializer.cs:line 264
   at Spring.Social.LinkedIn.Api.Impl.Json.LinkedInFullProfileDeserializer.Deserialize(JsonValue json, JsonMapper mapper) in f:\bamboo-home\xml-data\build-dir\SPRNETSOCIALLI-RELEASE-JOB1\src\Spring.Social.LinkedIn\Social\LinkedIn\Api\Impl\Json\LinkedInFullProfileDeserializer.cs:line 53
   at Spring.Json.JsonMapper.Deserialize[T](JsonValue value) in f:\bamboo-home\xml-data\build-dir\SPRNETREST-RELEASE-JOB1\src\Spring.Rest\Json\JsonMapper.cs:line 110
   at Spring.Http.Converters.Json.SpringJsonHttpMessageConverter.ReadInternal[T](IHttpInputMessage message) in f:\bamboo-home\xml-data\build-dir\SPRNETREST-RELEASE-JOB1\src\Spring.Rest\Http\Converters\Json\SpringJsonHttpMessageConverter.cs:line 144
   at Spring.Rest.Client.Support.MessageConverterResponseExtractor`1.ExtractData(IClientHttpResponse response) in f:\bamboo-home\xml-data\build-dir\SPRNETREST-RELEASE-JOB1\src\Spring.Rest\Rest\Client\Support\MessageConverterResponseExtractor.cs:line 97
   at Spring.Rest.Client.RestTemplate.DoExecute[T](Uri uri, HttpMethod method, IRequestCallback requestCallback, IResponseExtractor`1 responseExtractor) in f:\bamboo-home\xml-data\build-dir\SPRNETREST-RELEASE-JOB1\src\Spring.Rest\Rest\Client\RestTemplate.cs:line 2700
   at Spring.Rest.Client.RestTemplate.GetForObject[T](String url, Object[] uriVariables) in f:\bamboo-home\xml-data\build-dir\SPRNETREST-RELEASE-JOB1\src\Spring.Rest\Rest\Client\RestTemplate.cs:line 267
   at coderbits.Externals.Social.LinkedInOperations.GetAccount(OAuthToken token) in c:\Dropbox\Projects\coderbits\coderbits.Externals\ApiAccessLayer\Social\LinkedInOperations.cs:line 26
   at coderbits.Helpers.Social.LinkedInHelpers.FillDatabase(Int32 coderbitsAccountId, DataOperations dataOperations) in c:\Dropbox\Projects\coderbits\coderbits.DataAccess\Helpers\Social\LinkedInHelpers.cs:line 327
